### PR TITLE
Push addresses to the URL bar, make the header text clickable

### DIFF
--- a/packages/nextjs/components/address-vision/Navbar.tsx
+++ b/packages/nextjs/components/address-vision/Navbar.tsx
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router";
 import { Address } from "viem";
 import { AddressInput } from "~~/components/scaffold-eth";
 
@@ -7,9 +8,19 @@ interface NavbarProps {
 }
 
 export const Navbar = ({ searchedAddress, setSearchedAddress }: NavbarProps) => {
+  const router = useRouter();
+
+  const handleLogoClick = () => {
+    setSearchedAddress("");
+    router.push("/", undefined, { shallow: true });
+  };
+
   return (
     <div className="navbar sticky top-0 z-20 grid min-h-0 flex-shrink-0 grid-cols-12 justify-between bg-base-100 px-0 shadow-md shadow-secondary sm:px-2 lg:static">
-      <div className="col-start-4 flex flex-row items-center md:col-start-1 md:col-end-3">
+      <div
+        onClick={handleLogoClick}
+        className="col-start-4 flex flex-row items-center md:col-start-1 md:col-end-3 cursor-pointer"
+      >
         <div className="mb-4 text-4xl">👀</div>
         <h1 className="ml-2 text-2xl font-bold">address.vision</h1>
       </div>

--- a/packages/nextjs/components/address-vision/Navbar.tsx
+++ b/packages/nextjs/components/address-vision/Navbar.tsx
@@ -17,12 +17,13 @@ export const Navbar = ({ searchedAddress, setSearchedAddress }: NavbarProps) => 
 
   return (
     <div className="navbar sticky top-0 z-20 grid min-h-0 flex-shrink-0 grid-cols-12 justify-between bg-base-100 px-0 shadow-md shadow-secondary sm:px-2 lg:static">
-      <div
-        onClick={handleLogoClick}
-        className="col-start-4 flex flex-row items-center md:col-start-1 md:col-end-3 cursor-pointer"
-      >
-        <div className="mb-4 text-4xl">👀</div>
-        <h1 className="ml-2 text-2xl font-bold">address.vision</h1>
+      <div className="col-start-4 flex flex-row items-center md:col-start-1 md:col-end-3">
+        <div onClick={handleLogoClick} className="mb-4 text-4xl cursor-pointer">
+          👀
+        </div>
+        <h1 onClick={handleLogoClick} className="ml-2 text-2xl font-bold cursor-pointer">
+          address.vision
+        </h1>
       </div>
       <div className="col-start-2 col-end-12 row-start-2 flex justify-center md:col-start-4 md:col-end-10 md:row-auto">
         <div className="flex-grow">

--- a/packages/nextjs/pages/[[...address]].tsx
+++ b/packages/nextjs/pages/[[...address]].tsx
@@ -27,7 +27,7 @@ const Home: NextPage = () => {
       } else if (!searchedAddress) {
         router.push("/", undefined, { shallow: true });
       }
-    }, 50); // @remind not the best solution
+    }, 100); // @remind not the best solution
   }, [searchedAddress]);
 
   return (

--- a/packages/nextjs/pages/[[...address]].tsx
+++ b/packages/nextjs/pages/[[...address]].tsx
@@ -27,7 +27,7 @@ const Home: NextPage = () => {
       } else if (!searchedAddress) {
         router.push("/", undefined, { shallow: true });
       }
-    }, 100); // @remind not the best solution
+    }, 200); // @remind not the best solution
   }, [searchedAddress]);
 
   return (

--- a/packages/nextjs/pages/[[...address]].tsx
+++ b/packages/nextjs/pages/[[...address]].tsx
@@ -1,11 +1,34 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import type { NextPage } from "next";
+import { isAddress } from "viem";
 import * as chains from "wagmi/chains";
 import { AddressCard, ButtonsCard, Navbar, NetworkCard, QRCodeCard } from "~~/components/address-vision/";
 
 const Home: NextPage = () => {
   const [searchedAddress, setSearchedAddress] = useState("");
+  const router = useRouter();
+
+  useEffect(() => {
+    console.log("router.query: ", router.query);
+    if (router.query.address && Array.isArray(router.query.address)) {
+      const [address] = router.query.address;
+      if (address) {
+        setSearchedAddress(address);
+      }
+    }
+  }, [router.query]);
+
+  useEffect(() => {
+    setTimeout(() => {
+      if (searchedAddress && isAddress(searchedAddress)) {
+        router.push(`/${searchedAddress}`, undefined, { shallow: true });
+      } else if (!searchedAddress) {
+        router.push("/", undefined, { shallow: true });
+      }
+    }, 50); // @remind not the best solution
+  }, [searchedAddress]);
 
   return (
     <>


### PR DESCRIPTION
## Description

- Push addresses to the URL bar
- Make the header text clickable.

https://github.com/BuidlGuidl/address-vision-port/assets/108868128/5d5ab6e1-bfe7-4ef9-a449-54f6358b8813



I am aware that this might not be the best solution but let's try it and see if it works for multiple users.

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #4 _

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: portdev.eth
