### PR TITLE
Show a smaller size ens name if the ens name is too long

### DIFF
--- a/packages/nextjs/components/address-vision/AddressCard.tsx
+++ b/packages/nextjs/components/address-vision/AddressCard.tsx
@@ -25,10 +25,10 @@ export const AddressCard = ({ address }: { address: Address }) => {
           {address && (
             <>
               <div className="hidden md:block">
-                <AddressComp address={address} size="4xl" />
+                <AddressComp address={address} size="4xl" isAddressCard={true} />
               </div>
               <div className="block md:hidden">
-                <AddressComp address={address} size="3xl" />
+                <AddressComp address={address} size="3xl" isAddressCard={true} />
               </div>
             </>
           )}

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -126,7 +126,7 @@ export const Address = ({
         </span>
       ) : (
         <a
-          className={`ml-1.5 font-normal ${isAddressCard ? "text-2xl" : `text-${size}`}`}
+          className={`ml-1.5 font-normal ${isAddressCard && ens && ens.length > 20 ? "text-2xl" : `text-${size}`}`}
           target="_blank"
           href={blockExplorerAddressLink}
           rel="noopener noreferrer"

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -16,6 +16,7 @@ type TAddressProps = {
   format?: "short" | "long";
   size?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl" | "4xl";
   chain?: Chain;
+  isAddressCard?: boolean;
 };
 
 const blockieSizeMap = {
@@ -38,6 +39,7 @@ export const Address = ({
   format,
   size = "base",
   chain = chains.mainnet,
+  isAddressCard,
 }: TAddressProps) => {
   const [ens, setEns] = useState<string | null>();
   const [ensAvatar, setEnsAvatar] = useState<string | null>();
@@ -124,7 +126,7 @@ export const Address = ({
         </span>
       ) : (
         <a
-          className={`ml-1.5 text-${size} font-normal`}
+          className={`ml-1.5 font-normal ${isAddressCard ? "text-2xl" : `text-${size}`}`}
           target="_blank"
           href={blockExplorerAddressLink}
           rel="noopener noreferrer"


### PR DESCRIPTION
## Description

Show a smaller size ens name in address card component if the ens name is too long to fit the component.

Before:
![image](https://github.com/BuidlGuidl/address-vision-port/assets/108868128/d9a5a1ae-527b-471f-a445-0e050aec0ae8)

After:
![image](https://github.com/BuidlGuidl/address-vision-port/assets/108868128/40195e98-2614-4d08-9849-974fff268696)

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #7 _

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
