### PR TITLE
Remove See [address/ens] on text from h2s on cards

### DIFF
--- a/packages/nextjs/components/address-vision/ButtonsCard.tsx
+++ b/packages/nextjs/components/address-vision/ButtonsCard.tsx
@@ -89,16 +89,13 @@ export const ButtonsCard = ({ address }: { address: Address }) => {
     return (
       <div className="card w-[370px] md:w-[425px] bg-base-100 shadow-xl">
         <div className="card-body">
-          <h2 className="card-title">
-            See
-            <AddressComp address={address} />
-            on
+          <div className="text-xl flex">
+            <p>This is a contract, see it on</p>
             <Link href={`https://abi.ninja/${address}/mainnet`} className="flex underline items-center">
               <Image src="/abininja-logo.svg" width={50} height={50} alt="abi.ninja logo" />
               abi.ninja
             </Link>
-          </h2>
-          <div className="text-xl">This is a contract!</div>
+          </div>
         </div>
       </div>
     );
@@ -109,9 +106,6 @@ export const ButtonsCard = ({ address }: { address: Address }) => {
       <div className="card w-[370px] md:w-[425px] bg-base-100 shadow-xl">
         <div className="card-body">
           <h2 className="card-title">
-            See
-            <AddressComp address={address} />
-            on
             <Link href={`https://app.safe.global/home?safe=eth:${address}`} className="flex underline items-center">
               <Image
                 src={isDarkMode ? "/safe-logo-light.svg" : "/safe-logo-dark.svg"}
@@ -145,14 +139,6 @@ export const ButtonsCard = ({ address }: { address: Address }) => {
     return (
       <div className="card w-[370px] md:w-[425px] bg-base-100 shadow-xl">
         <div className="card-body">
-          <h2 className="card-title">
-            See
-            <div className="flex items-center space-x-4">
-              <div className="rounded-md bg-slate-300 h-6 w-6"></div>
-              <div className="h-2 w-28 bg-slate-300 rounded"></div>
-            </div>
-            on
-          </h2>
           <div className="animate-pulse">
             <div className="grid grid-cols-2 gap-2 md:grid-cols-3 lg:grid-cols-3">
               {[1, 2, 3, 4, 5, 6].map(i => (
@@ -168,11 +154,6 @@ export const ButtonsCard = ({ address }: { address: Address }) => {
   return (
     <div className="card w-[370px] md:w-[425px] bg-base-100 shadow-xl">
       <div className="card-body">
-        <h2 className="card-title">
-          See
-          <AddressComp address={address} />
-          on
-        </h2>
         <div className="grid grid-cols-2 gap-2 md:grid-cols-3 lg:grid-cols-3">
           <button
             className="btn btn-primary btn-xs rounded-full"

--- a/packages/nextjs/components/address-vision/NetworkCard.tsx
+++ b/packages/nextjs/components/address-vision/NetworkCard.tsx
@@ -83,7 +83,6 @@ export const NetworkCard = ({ address, chain }: { address: Address; chain: Chain
       <div className="card w-[370px] md:w-[425px] bg-base-100 shadow-xl flex-grow animate-pulse">
         <div className="card-body">
           <div className="flex items-center space-x-4">
-            <div className="rounded-md bg-slate-300 h-6 w-6"></div>
             <div className="h-2 w-28 bg-slate-300 rounded"></div>
           </div>
 

--- a/packages/nextjs/components/address-vision/NetworkCard.tsx
+++ b/packages/nextjs/components/address-vision/NetworkCard.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { Address as AddressComp } from "../scaffold-eth";
 import { NftsCarousel } from "./NftsCarousel";
 import { TokensTable } from "./TokensTable";
 import { CovalentClient } from "@covalenthq/client-sdk";
@@ -141,7 +140,6 @@ export const NetworkCard = ({ address, chain }: { address: Address; chain: Chain
       <div className="card w-[370px] md:w-[425px] bg-base-100 shadow-xl flex-grow">
         <div className="card-body">
           <h2 className="card-title whitespace-nowrap">
-            <AddressComp address={address} chain={chain} /> on{" "}
             <Link
               href={getBlockExplorerAddressLink(chain, address)}
               rel="noopener noreferrer"


### PR DESCRIPTION
## Description

This PR removes the See [address/ens] on... headers from all cards in the app.
![image](https://github.com/BuidlGuidl/address-vision-port/assets/108868128/5522ff7a-1008-4739-a937-b7fad344feb7)

See the changes on: [https://address-vision-port-git-feat-remove-see-on-buidlguidldao.vercel.app/](url)


## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #17 _

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: portdev.eth
