### PR TITLE
Add ref to the searchbar for focus

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -53,6 +53,7 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
 
   return (
     <InputBase<Address>
+      autoFocus={true}
       name={name}
       placeholder={placeholder}
       error={ensAddress === null}

--- a/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
@@ -1,10 +1,11 @@
-import { ChangeEvent, ReactNode, useCallback } from "react";
+import { ChangeEvent, ReactNode, useCallback, useEffect, useRef } from "react";
 import { CommonInputProps } from "~~/components/scaffold-eth";
 
 type InputBaseProps<T> = CommonInputProps<T> & {
   error?: boolean;
   prefix?: ReactNode;
   suffix?: ReactNode;
+  autoFocus?: boolean;
 };
 
 export const InputBase = <T extends { toString: () => string } | undefined = string>({
@@ -16,6 +17,7 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
   disabled,
   prefix,
   suffix,
+  autoFocus,
 }: InputBaseProps<T>) => {
   let modifier = "";
   if (error) {
@@ -23,6 +25,14 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
   } else if (disabled) {
     modifier = "border-disabled bg-base-300";
   }
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (autoFocus && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [autoFocus]);
 
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -35,6 +45,7 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
     <div className={`flex border-2 border-base-300 bg-base-200 rounded-full text-accent ${modifier}`}>
       {prefix}
       <input
+        ref={inputRef} // Attach ref to the input element
         className="input input-ghost focus:outline-none focus:bg-transparent focus:text-gray-400 h-[2.2rem] min-h-[2.2rem] px-4 border w-full font-medium placeholder:text-accent/50 text-gray-400"
         placeholder={placeholder}
         name={name}


### PR DESCRIPTION
## Description

Focus the searchbar on page load. Changes the behavior of all AddressInputs, but since we just have one, it won't be a problem imo.

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #19 _

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: portdev.eth
