### PR TITLE
Trim eth: if it is there, sort tailwind classes

### DIFF
--- a/packages/nextjs/components/address-vision/Navbar.tsx
+++ b/packages/nextjs/components/address-vision/Navbar.tsx
@@ -16,16 +16,17 @@ export const Navbar = ({ searchedAddress, setSearchedAddress }: NavbarProps) => 
   };
 
   const handleAddressChange = (address: string) => {
-    setSearchedAddress(address.trim());
+    const trimmedAddress = address.startsWith("eth:") ? address.slice(4) : address;
+    setSearchedAddress(trimmedAddress.trim());
   };
 
   return (
     <div className="navbar sticky top-0 z-20 grid min-h-0 flex-shrink-0 grid-cols-12 justify-between bg-base-100 px-0 shadow-md shadow-secondary sm:px-2 lg:static">
       <div className="col-start-4 flex flex-row items-center md:col-start-1 md:col-end-3">
-        <div onClick={handleLogoClick} className="mb-4 text-4xl cursor-pointer">
+        <div onClick={handleLogoClick} className="mb-4 cursor-pointer text-4xl">
           👀
         </div>
-        <h1 onClick={handleLogoClick} className="ml-2 text-2xl font-bold cursor-pointer">
+        <h1 onClick={handleLogoClick} className="ml-2 cursor-pointer text-2xl font-bold">
           address.vision
         </h1>
       </div>


### PR DESCRIPTION
## Description

This PR removes the eth: tag if it is there when pasting in an address into the address search bar.

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #22 

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: portdev.eth
