### PR TITLE
Fix/minor fixes

### DIFF
--- a/packages/nextjs/components/Footer.tsx
+++ b/packages/nextjs/components/Footer.tsx
@@ -13,13 +13,13 @@ export const Footer = () => {
   const nativeCurrencyPrice = useGlobalState(state => state.nativeCurrencyPrice);
 
   return (
-    <div className="min-h-0 py-5 px-1 mb-11 lg:mb-0">
+    <div className="mb-11 min-h-0 px-1 py-5 lg:mb-0">
       <div>
-        <div className="fixed flex justify-between items-center w-full z-10 p-4 bottom-0 left-0 pointer-events-none">
-          <div className="flex space-x-2 pointer-events-auto">
+        <div className="pointer-events-none fixed bottom-0 left-0 z-10 flex w-full items-center justify-between p-4">
+          <div className="pointer-events-auto flex space-x-2">
             {nativeCurrencyPrice > 0 && (
-              <div className="btn btn-primary btn-sm font-normal cursor-auto gap-0">
-                <CurrencyDollarIcon className="h-4 w-4 mr-0.5" />
+              <div className="btn btn-primary btn-sm cursor-auto gap-0 font-normal">
+                <CurrencyDollarIcon className="mr-0.5 h-4 w-4" />
                 <span>{nativeCurrencyPrice}</span>
               </div>
             )}
@@ -30,7 +30,7 @@ export const Footer = () => {
       </div>
       <div className="w-full">
         <ul className="menu menu-horizontal w-full">
-          <div className="flex justify-center items-center gap-2 text-sm w-full">
+          <div className="flex w-full items-center justify-center gap-2 text-sm">
             <div className="text-center">
               <a
                 href="https://github.com/BuidlGuidl/address-vision-port"
@@ -54,17 +54,6 @@ export const Footer = () => {
                   BuidlGuidl
                 </a>
               </p>
-            </div>
-            <span>·</span>
-            <div className="text-center">
-              <a
-                href="https://t.me/joinchat/KByvmRe5wkR-8F_zz6AjpA"
-                target="_blank"
-                rel="noreferrer"
-                className="underline underline-offset-2"
-              >
-                Support
-              </a>
             </div>
           </div>
         </ul>

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -87,10 +87,10 @@ export const Address = ({
   // Skeleton UI
   if (!address) {
     return (
-      <div className="animate-pulse flex space-x-4">
-        <div className="rounded-md bg-slate-300 h-6 w-6"></div>
+      <div className="flex animate-pulse space-x-4">
+        <div className="h-6 w-6 rounded-md bg-slate-300"></div>
         <div className="flex items-center space-y-6">
-          <div className="h-2 w-28 bg-slate-300 rounded"></div>
+          <div className="h-2 w-28 rounded bg-slate-300"></div>
         </div>
       </div>
     );
@@ -135,7 +135,10 @@ export const Address = ({
         </a>
       )}
       {addressCopied ? (
-        <CheckCircleIcon className="ml-1  font-normal text-neutral h-4 w-4 cursor-pointer" aria-hidden="true" />
+        <CheckCircleIcon
+          className="ml-1 mt-3 h-4 w-4 cursor-pointer self-start font-normal text-neutral"
+          aria-hidden="true"
+        />
       ) : (
         <CopyToClipboard
           text={address}
@@ -146,7 +149,10 @@ export const Address = ({
             }, 800);
           }}
         >
-          <DocumentDuplicateIcon className="ml-1 font-normal text-neutral h-4 w-4 cursor-pointer" aria-hidden="true" />
+          <DocumentDuplicateIcon
+            className="ml-1 mt-3 h-4 w-4 cursor-pointer self-start font-normal text-neutral"
+            aria-hidden="true"
+          />
         </CopyToClipboard>
       )}
     </div>

--- a/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/AddressInput.tsx
@@ -62,7 +62,7 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
       disabled={isEnsAddressLoading || isEnsNameLoading || disabled}
       prefix={
         ensName && (
-          <div className="flex bg-base-300 rounded-l-full items-center">
+          <div className="flex items-center rounded-l-full bg-base-300">
             {ensAvatar ? (
               <span className="w-[35px]">
                 {
@@ -71,7 +71,7 @@ export const AddressInput = ({ value, name, placeholder, onChange, disabled }: C
                 }
               </span>
             ) : null}
-            <span className="text-neutral px-2">{enteredEnsName ?? ensName}</span>
+            <span className="pb-1 pl-3 pr-2 leading-none text-neutral">{enteredEnsName ?? ensName}</span>
           </div>
         )
       }

--- a/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/InputBase.tsx
@@ -46,7 +46,7 @@ export const InputBase = <T extends { toString: () => string } | undefined = str
       {prefix}
       <input
         ref={inputRef} // Attach ref to the input element
-        className="input input-ghost focus:outline-none focus:bg-transparent focus:text-gray-400 h-[2.2rem] min-h-[2.2rem] px-4 border w-full font-medium placeholder:text-accent/50 text-gray-400"
+        className="input input-ghost h-[2.2rem] min-h-[2.2rem] w-full border px-4 pb-0.5 font-medium text-gray-400 placeholder:text-accent/50 focus:bg-transparent focus:text-gray-400 focus:outline-none"
         placeholder={placeholder}
         name={name}
         value={value?.toString()}


### PR DESCRIPTION
## Description

This PR:
-> removes the Support link from the footer #25 

-> centers ens and address in address input #26 
![image](https://github.com/BuidlGuidl/address-vision-port/assets/108868128/07faf88a-2877-4e9e-90a4-738747bf811d)

-> adds a copy icon in address card #24 
![image](https://github.com/BuidlGuidl/address-vision-port/assets/108868128/bc33ac7a-3ed6-4571-82a7-8aca2c3d4097)


Since the changes are relatively small, I am submitting them as one PR. Let me know if I should seperate PRs or not.

For a better look in address input I think we can redo it all together in terms of styling.

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #24 #25 #26 

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: portdev.eth
