### PR TITLE
Show previous searches on homepage

### DIFF
--- a/packages/nextjs/components/address-vision/AddressCard.tsx
+++ b/packages/nextjs/components/address-vision/AddressCard.tsx
@@ -1,43 +1,75 @@
 import { Address as AddressComp, Balance } from "../scaffold-eth";
 import { Address, isAddress } from "viem";
 import * as chains from "wagmi/chains";
+import { XMarkIcon } from "@heroicons/react/24/outline";
 import { isValidEnsOrAddress } from "~~/utils/scaffold-eth";
 
-export const AddressCard = ({ address }: { address: Address }) => {
+export const AddressCard = ({
+  address,
+  isSmallCard = false,
+  removeAddress,
+}: {
+  address: Address;
+  isSmallCard?: boolean;
+  removeAddress?: () => void;
+}) => {
+  const cardSizeClass = isSmallCard
+    ? "flex-shrink-0 w-[350px] md:w-[250px] max-w-[350px] h-[100px]"
+    : "flex-shrink-0 w-[370px] md:w-[425px] max-w-[425px]";
+  const titleSizeClass = isSmallCard ? "text-md" : "text-xl";
+  const balanceSizeClass = isSmallCard ? "text-md pt-0" : "text-xl";
+
   if (!isAddress(address)) {
     return (
-      <div className="card w-[370px] md:w-[425px] bg-base-100 shadow-xl flex flex-col">
+      <div className={`card ${cardSizeClass} bg-base-100 shadow-xl flex flex-col`}>
         <div className="card-body flex-grow pb-0 animate-pulse">
-          <h2 className="card-title">
+          <h2 className={`card-title ${titleSizeClass}`}>
             <div className="h-10 w-48 bg-slate-300 rounded"></div>
           </h2>
         </div>
-        <div className="card-actions flex items-center justify-end p-4 text-xl animate-pulse">
+        <div className={`card-actions flex items-center justify-end p-4 ${balanceSizeClass} animate-pulse`}>
           Balance: <div className="h-6 w-24 bg-slate-300 rounded"></div>
         </div>
       </div>
     );
   }
+
   return (
-    <div className="card w-[370px] md:w-[425px] bg-base-100 shadow-xl flex flex-col">
-      <div className="card-body flex-grow pb-0">
-        <h2 className="card-title">
+    <div className={`card ${cardSizeClass} bg-base-100 shadow-xl flex flex-col p-6`}>
+      <div className={`card-body p-0`}>
+        <h2 className={`card-title ${titleSizeClass}`}>
           {address && (
             <>
               <div className="hidden md:block">
-                <AddressComp address={address} size="4xl" isAddressCard={true} />
+                <AddressComp
+                  address={address}
+                  size={isSmallCard ? "xl" : "4xl"}
+                  isAddressCard={true}
+                  isSmallCard={true}
+                />
               </div>
               <div className="block md:hidden">
-                <AddressComp address={address} size="3xl" isAddressCard={true} />
+                <AddressComp
+                  address={address}
+                  size={isSmallCard ? "lg" : "3xl"}
+                  isAddressCard={true}
+                  isSmallCard={true}
+                />
               </div>
             </>
           )}
         </h2>
+        {isSmallCard && (
+          <XMarkIcon
+            className="absolute top-2 right-2 h-6 w-6 text-gray-400 hover:cursor-pointer hover:text-black"
+            onClick={removeAddress}
+          />
+        )}
       </div>
-      <div className="card-actions flex items-center justify-end p-4 text-xl">
+      <div className={`card-actions flex items-center justify-end ${balanceSizeClass}`}>
         Balance:{" "}
         {address && isValidEnsOrAddress(address) ? (
-          <Balance address={address} targetNetwork={chains.mainnet} className="text-2xl" />
+          <Balance address={address} targetNetwork={chains.mainnet} className={isSmallCard ? "text-md" : "text-2xl"} />
         ) : (
           <p>search for an address</p>
         )}

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -17,6 +17,7 @@ type TAddressProps = {
   size?: "xs" | "sm" | "base" | "lg" | "xl" | "2xl" | "3xl" | "4xl";
   chain?: Chain;
   isAddressCard?: boolean;
+  isSmallCard?: boolean;
 };
 
 const blockieSizeMap = {
@@ -40,6 +41,7 @@ export const Address = ({
   size = "base",
   chain = chains.mainnet,
   isAddressCard,
+  isSmallCard = false,
 }: TAddressProps) => {
   const [ens, setEns] = useState<string | null>();
   const [ensAvatar, setEnsAvatar] = useState<string | null>();
@@ -136,7 +138,9 @@ export const Address = ({
       )}
       {addressCopied ? (
         <CheckCircleIcon
-          className="ml-1 mt-3 h-4 w-4 cursor-pointer self-start font-normal text-neutral"
+          className={`ml-1 ${
+            isSmallCard ? "h-5 w-5" : "mt-3 h-4 w-4"
+          } cursor-pointer self-start font-normal text-neutral`}
           aria-hidden="true"
         />
       ) : (
@@ -150,7 +154,9 @@ export const Address = ({
           }}
         >
           <DocumentDuplicateIcon
-            className="ml-1 mt-3 h-4 w-4 cursor-pointer self-start font-normal text-neutral"
+            className={`ml-1 ${
+              isSmallCard ? "h-5 w-5" : "mt-3 h-4 w-4"
+            } cursor-pointer self-start font-normal text-neutral`}
             aria-hidden="true"
           />
         </CopyToClipboard>

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -120,6 +120,7 @@ module.exports = {
       "sm": "400px",
       "md": "1000px",
       "lg": "1400px",
+      "xl": "1800px",
     },
   },
 };


### PR DESCRIPTION
## Description

This PR:
- adds each searched address to localStorage
- shows the previously searched addresses in a grid with an X button on topright
- adds a new breakpoint of xl: 1800 px


## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #28 _

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address: portdev.eth
