### PR TITLE
Resolve and push the ens to urlbar in Navbar

### DIFF
--- a/packages/nextjs/components/address-vision/AddressCard.tsx
+++ b/packages/nextjs/components/address-vision/AddressCard.tsx
@@ -37,7 +37,7 @@ export const AddressCard = ({
   return (
     <div className={`card ${cardSizeClass} bg-base-100 shadow-xl flex flex-col p-6`}>
       <div className={`card-body p-0`}>
-        <h2 className={`card-title ${titleSizeClass}`}>
+        <h2 className={`card-title -mb-1 ${titleSizeClass}`}>
           {address && (
             <>
               <div className="hidden md:block">

--- a/packages/nextjs/components/address-vision/Navbar.tsx
+++ b/packages/nextjs/components/address-vision/Navbar.tsx
@@ -2,8 +2,15 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { QrScanner } from "@yudiel/react-qr-scanner";
 import { Address, isAddress } from "viem";
+import { createPublicClient, http } from "viem";
+import { mainnet } from "viem/chains";
 import { QrCodeIcon } from "@heroicons/react/24/outline";
 import { AddressInput } from "~~/components/scaffold-eth";
+
+const client = createPublicClient({
+  chain: mainnet,
+  transport: http(),
+});
 
 interface NavbarProps {
   searchedAddress: Address;
@@ -33,6 +40,12 @@ export const Navbar = ({ searchedAddress, setSearchedAddress }: NavbarProps) => 
     }
     if (inputValue.endsWith(".eth")) {
       router.push(`/${inputValue}`, undefined, { shallow: true });
+    } else if (isAddress(trimmedAddress)) {
+      async function getEnsName(address: string) {
+        const ensName = await client.getEnsName({ address });
+        router.push(`/${ensName || address}`, undefined, { shallow: true });
+      }
+      getEnsName(trimmedAddress);
     }
   }, [inputValue]);
 

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -20,16 +20,16 @@ type TAddressProps = {
   isSmallCard?: boolean;
 };
 
-const blockieSizeMap = {
-  xs: 6,
-  sm: 7,
-  base: 8,
-  lg: 9,
-  xl: 10,
-  "2xl": 12,
-  "3xl": 15,
-  "4xl": 20,
-};
+// const blockieSizeMap = {
+//   xs: 6,
+//   sm: 7,
+//   base: 8,
+//   lg: 9,
+//   xl: 10,
+//   "2xl": 12,
+//   "3xl": 15,
+//   "4xl": 20,
+// };
 
 /**
  * Displays an address (or ENS) with a Blockie image and option to copy address.
@@ -128,22 +128,14 @@ export const Address = ({
   return (
     <div className="flex">
       {disableAddressLink || !isSmallCard ? (
-        <div className="flex">
-          <BlockieAvatar
-            address={address}
-            ensImage={ensAvatar}
-            size={(blockieSizeMap[size] * 24) / blockieSizeMap["base"]}
-          />
-          <span className={`ml-1.5 mt-0.5 text-${size} font-normal`}>{displayAddress}</span>
+        <div className=" flex items-center justify-center ">
+          <BlockieAvatar address={address} ensImage={ensAvatar} size={16} />
+          <span className={`ml-1.5 -mt-2  text-${size} font-normal`}>{displayAddress}</span>
         </div>
       ) : getTargetNetwork().id === hardhat.id ? (
         <Link href={`/${address}`}>
           <a className={`flex ${isAddressCard ? getTextSizeClass(ens?.length || 0) : `text-${size}`}`}>
-            <BlockieAvatar
-              address={address}
-              ensImage={ensAvatar}
-              size={(blockieSizeMap[size] * 24) / blockieSizeMap["base"]}
-            />
+            <BlockieAvatar address={address} ensImage={ensAvatar} size={16} />
             <span className={`ml-1.5 font-normal`}>{displayAddress}</span>
           </a>
         </Link>
@@ -154,12 +146,8 @@ export const Address = ({
           href={ens ? `/${ens}` : `/${address}`}
           rel="noopener noreferrer"
         >
-          <BlockieAvatar
-            address={address}
-            ensImage={ensAvatar}
-            size={(blockieSizeMap[size] * 24) / blockieSizeMap["base"]}
-          />
-          <span className={`ml-1.5 -m-0.5 font-normal`}>{displayAddress}</span>
+          <BlockieAvatar address={address} ensImage={ensAvatar} size={10} />
+          <span className={`ml-1.5 mt-0.5 font-normal`}>{displayAddress}</span>
         </Link>
       )}
       {addressCopied ? (

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -148,7 +148,7 @@ export const Address = ({
           </a>
         </Link>
       ) : (
-        <a
+        <Link
           className={`flex items-center ${isAddressCard ? getTextSizeClass(ens?.length || 0) : `text-${size}`}`}
           target={"_self"}
           href={ens ? `/${ens}` : `/${address}`}
@@ -160,7 +160,7 @@ export const Address = ({
             size={(blockieSizeMap[size] * 24) / blockieSizeMap["base"]}
           />
           <span className={`ml-1.5 font-normal`}>{displayAddress}</span>
-        </a>
+        </Link>
       )}
       {addressCopied ? (
         <CheckCircleIcon

--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -126,19 +126,19 @@ export const Address = ({
   };
 
   return (
-    <div className="flex items-center">
+    <div className="flex">
       {disableAddressLink || !isSmallCard ? (
-        <div className="flex items-center">
+        <div className="flex">
           <BlockieAvatar
             address={address}
             ensImage={ensAvatar}
             size={(blockieSizeMap[size] * 24) / blockieSizeMap["base"]}
           />
-          <span className={`ml-1.5 text-${size} font-normal`}>{displayAddress}</span>
+          <span className={`ml-1.5 mt-0.5 text-${size} font-normal`}>{displayAddress}</span>
         </div>
       ) : getTargetNetwork().id === hardhat.id ? (
         <Link href={`/${address}`}>
-          <a className={`flex items-center ${isAddressCard ? getTextSizeClass(ens?.length || 0) : `text-${size}`}`}>
+          <a className={`flex ${isAddressCard ? getTextSizeClass(ens?.length || 0) : `text-${size}`}`}>
             <BlockieAvatar
               address={address}
               ensImage={ensAvatar}
@@ -149,7 +149,7 @@ export const Address = ({
         </Link>
       ) : (
         <Link
-          className={`flex items-center ${isAddressCard ? getTextSizeClass(ens?.length || 0) : `text-${size}`}`}
+          className={`flex ${isAddressCard ? getTextSizeClass(ens?.length || 0) : `text-${size}`}`}
           target={"_self"}
           href={ens ? `/${ens}` : `/${address}`}
           rel="noopener noreferrer"
@@ -159,7 +159,7 @@ export const Address = ({
             ensImage={ensAvatar}
             size={(blockieSizeMap[size] * 24) / blockieSizeMap["base"]}
           />
-          <span className={`ml-1.5 font-normal`}>{displayAddress}</span>
+          <span className={`ml-1.5 -m-0.5 font-normal`}>{displayAddress}</span>
         </Link>
       )}
       {addressCopied ? (

--- a/packages/nextjs/components/scaffold-eth/BlockieAvatar.tsx
+++ b/packages/nextjs/components/scaffold-eth/BlockieAvatar.tsx
@@ -1,15 +1,13 @@
+/* eslint-disable @next/next/no-img-element */
 import { AvatarComponent } from "@rainbow-me/rainbowkit";
 import { blo } from "blo";
 
-// Custom Avatar for RainbowKit
 export const BlockieAvatar: AvatarComponent = ({ address, ensImage, size }) => (
-  // Don't want to use nextJS Image here (and adding remote patterns for the URL)
-  // eslint-disable-next-line @next/next/no-img-element
-  <img
-    className="rounded-full"
-    src={ensImage || blo(address as `0x${string}`)}
-    width={size}
-    height={size}
-    alt={`${address} avatar`}
-  />
+  <div className={`h-${size} w-${size} overflow-hidden rounded-full bg-gray-100 flex items-center justify-center`}>
+    <img
+      className="object-cover min-w-full min-h-full"
+      src={ensImage || blo(address as `0x${string}`)}
+      alt={`${address} avatar`}
+    />
+  </div>
 );


### PR DESCRIPTION
## Description

This PR fixes a logic issue in resolving and putting the ENS into the URL bar.

Before the fix, if the user searches for an address, it stays as an address and does not get pushed to the router because it does not end with ".ens", now we resolve to an ENS thanks to viem's getEnsName method.

Since the changes are small, I didn't open an issue first. 


Before: 

https://github.com/BuidlGuidl/address-vision-port/assets/108868128/40dda768-83b1-4879-9634-38c2078036e3


After:

https://github.com/BuidlGuidl/address-vision-port/assets/108868128/3a02c097-ef0e-4bd4-abc4-70a99e50e863




## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
