### PR TITLE
Add EOF check

### DIFF
--- a/packages/nextjs/components/address-vision/ButtonsCard.tsx
+++ b/packages/nextjs/components/address-vision/ButtonsCard.tsx
@@ -49,7 +49,7 @@ export const ButtonsCard = () => {
       if (!address || !client) return;
       try {
         const bytecode = await client.getCode({ address });
-        const isContract = bytecode && bytecode.length > 2;
+        const isContract = bytecode && bytecode.length > 2 && !bytecode.startsWith("0xef01");
 
         setIsContractAddress(isContract || false);
 


### PR DESCRIPTION
Austin's address returns "0xef010063c0c19a282a1b52b07dd5a65b58948a07dae32b" on getBytecode. 
I added a check that prevents eof addresses from getting labeled as contracts.

fixes #84 
