### PR TITLE
fix: token balance decimal formatting based on integer

### DIFF
--- a/packages/nextjs/components/address-vision/TokensTable.tsx
+++ b/packages/nextjs/components/address-vision/TokensTable.tsx
@@ -19,9 +19,9 @@ export const TokensTable = ({ tokens }: { tokens: Token[] }) => {
 
     if (integerPartStr.length > 10) {
       return `${integerPartStr.slice(0, 10)}...`;
-    } else {
-      return `${integerPartStr}.${formattedFractionalPart}`;
     }
+    const formatted = `${integerPartStr}.${formattedFractionalPart}`;
+    return formatted === "0.000000" ? "0" : formatted;
   };
 
   if (tokens.length === 0) {


### PR DESCRIPTION
The number of decimals shown in the token balance is dynamic: if the integer part is zero, 6 decimals are shown, if it's less than 10, 4 decimals are shown, and in all other cases, 2 decimals are shown. 

<img width="421" height="256" alt="image" src="https://github.com/user-attachments/assets/ee6b6eb4-fc01-4fd7-b5f5-7f86ab12126e" />

fixes #81
