### PR TITLE
Strip colon-prefixed protocols from pasted addresses

### DIFF
--- a/packages/nextjs/components/address-vision/Navbar.tsx
+++ b/packages/nextjs/components/address-vision/Navbar.tsx
@@ -57,10 +57,10 @@ export const Navbar = () => {
   useEffect(() => {
     setEnsName("");
     let trimmedAddress = inputValue.trim();
-    if (trimmedAddress.startsWith("eth:")) {
-      trimmedAddress = trimmedAddress.slice(4);
-    } else if (trimmedAddress.startsWith("oeth:")) {
-      trimmedAddress = trimmedAddress.slice(5);
+    // Remove any prefix with colon (e.g., "xyz:", "abc:", "eth:", etc.)
+    const colonIndex = trimmedAddress.indexOf(":");
+    if (colonIndex !== -1) {
+      trimmedAddress = trimmedAddress.slice(colonIndex + 1);
     }
 
     if (trimmedAddress.endsWith(".eth") || trimmedAddress.endsWith(".xyz") || trimmedAddress.endsWith(".com")) {


### PR DESCRIPTION
## Summary
- Removes any colon-prefixed protocol (e.g., `xyz:`, `abc:`, `eth:`) from pasted addresses automatically

## Test plan
- [ ] Paste an address with `xyz:0x123...` and verify it strips to `0x123...`
- [ ] Paste an address with `abc:vitalik.eth` and verify it strips to `vitalik.eth`
- [ ] Paste normal addresses without prefixes and verify they still work